### PR TITLE
add validate_cmd_prefix - closes #3.

### DIFF
--- a/clippy/clippy.py
+++ b/clippy/clippy.py
@@ -252,7 +252,8 @@ class Clippy:
         Calls _exec.
         '''
         self.logger.debug(f'Validating {cmd}')
-        p = _exec([cmd, DRY_RUN_FLAG], submission_dict, self.logger)
+        validate_cmd_prefix = config.validate_cmd_prefix.split()
+        p = _exec(validate_cmd_prefix + [cmd, DRY_RUN_FLAG], submission_dict, self.logger)
         if p.returncode:
             raise ClippyValidationError(p.stderr)
 

--- a/clippy/config.py
+++ b/clippy/config.py
@@ -7,6 +7,11 @@
 # for instance, if using slurm this could be set to 'srun -n1 -ppdebug'
 cmd_prefix = ''
 
+# command prefix used to specify clippy task management with the HPC cluster
+# for dry runs in certain environments. For instance, if using slurm this
+# could be set to 'srun -n1 -ppdebug'
+validate_cmd_prefix = ''
+
 # contol the log level of clippy
 loglevel = 0
 


### PR DESCRIPTION
I think we want to eventually revisit the whole `config` approach but for now this should close #3.