### PR TITLE
first cut at typing.

### DIFF
--- a/clippy/__init__.py
+++ b/clippy/__init__.py
@@ -3,16 +3,25 @@
 #
 # SPDX-License-Identifier: MIT
 
+# TODO: SAB 20240204 finish typing
+
 import warnings
 from clippy.clippy import Clippy
 import inspect
 
+from typing import Any, Dict
+
+# TODO: SAB 20240206 - replace any instances of AnyDict with more specific types.
+AnyDict = Dict[str, Any]
+
+
 class ClippyRebindWarning(UserWarning):
     pass
 
-def clippy_import(backend_path, namespace=None):
+
+def clippy_import(backend_path: str, namespace: str = ""):
     """
-    Imports clippy-wrapped functions into the local python environment. 
+    Imports clippy-wrapped functions into the local python environment.
 
     backend_path is a string file path to a directory containing backend function executables
 
@@ -42,23 +51,27 @@ def clippy_import(backend_path, namespace=None):
 
     c = Clippy(backend_config)
 
-    caller_locals = inspect.currentframe().f_back.f_locals
-    
+    caller_locals = {}
+    currframe = inspect.currentframe()
+    if currframe is not None and currframe.f_back is not None:
+        caller_locals = currframe.f_back.f_locals
+
     if namespace:
-        # TODO on subsequent calls to clippy_import we want to 
-        #      union the members of the namespace with any existing 
-        #      namespace. Currently this only allows a namespace 
+        # TODO on subsequent calls to clippy_import we want to
+        #      union the members of the namespace with any existing
+        #      namespace. Currently this only allows a namespace
         #      (and thus it's members) to be added once.
         _bind_to_local_environment(caller_locals, c, namespace)
-    else:    
+    else:
         for ns in backend_config:
             nsobj = getattr(c, ns)
             for fn_name in nsobj.methods:
                 _bind_to_local_environment(caller_locals, nsobj, fn_name)
             for class_name in nsobj.classes:
                 _bind_to_local_environment(caller_locals, nsobj, class_name)
-    
-def _bind_to_local_environment(caller_locals, src_obj, src_name):
+
+
+def _bind_to_local_environment(caller_locals: AnyDict, src_obj, src_name: str):
     if src_name in caller_locals:
         warnings.warn(f"{src_name} already exists in local environment, skipping rebind...", ClippyRebindWarning)
         return

--- a/clippy/clippy.py
+++ b/clippy/clippy.py
@@ -15,7 +15,7 @@ from clippy.regcommand import get_registered_commands
 from clippy import config, AnyDict
 from clippy.serialization import encode_clippy_json, decode_clippy_json
 
-from typing import Any, List, Dict, Callable, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import Callable, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from subprocess import CompletedProcess

--- a/clippy/clippy.py
+++ b/clippy/clippy.py
@@ -12,14 +12,20 @@ import inspect
 from subprocess import run
 from clippy.error import ClippyBackendError, ClippyValidationError
 from clippy.regcommand import get_registered_commands
-from clippy import config
+from clippy import config, AnyDict
 from clippy.serialization import encode_clippy_json, decode_clippy_json
 
+from typing import Any, List, Dict, Callable, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from subprocess import CompletedProcess
+
+
 #  Set this to the clippy executable flag that does validation of stdin.
-DRY_RUN_FLAG = '--clippy-validate'
+DRY_RUN_FLAG: str = '--clippy-validate'
 
 
-def _exec(execcmd, submission_dict, logger):
+def _exec(execcmd: Union[str, Sequence[str]], submission_dict: AnyDict, logger: logging.Logger) -> CompletedProcess:
     '''
     Internal function.
 
@@ -47,18 +53,18 @@ class Command():
     An object that contains information relating to valid back-end commands.
     '''
 
-    def __init__(self, namespace, name, session, jsondict):
+    def __init__(self, namespace: str, name: str, session: "Clippy", jsondict: AnyDict):
         self.namespace = namespace
         self.name = name  # name of method
         self.session = session
         self.jsondict = jsondict
-        self.positionals = {}
+        self.positionals: AnyDict = {}
         for (arg, argparams) in self.args.items():   # self.args is defined below as a @property
             if argparams.get('position', -1) != -1:  # if position is not -1, this is a 0-indexed positional arg.
                 self.session.logger.debug(f'  adding positional {arg} at {argparams["position"]}.')
                 self.positionals[argparams['position']] = arg
 
-    def genfn(self, docstring):
+    def genfn(self, docstring: str) -> Callable:
         '''
         Generates a function and sets its docstring.
         The returned function is used to dynamically
@@ -103,13 +109,13 @@ class Command():
         return f
 
     @property
-    def args(self):
+    def args(self) -> AnyDict:
         return self.jsondict.get('args', {})
 
     @property
-    def docstring(self):
-        posargs = [None] * len(self.args)  # we're probably overallocating here but whatever.
-        optargs = []
+    def docstring(self) -> str:
+        posargs: List[Optional[Tuple[str, AnyDict]]] = [None] * len(self.args)  # we're probably overallocating here but whatever.
+        optargs: List[Tuple[str, AnyDict]] = []
         numpos = -1
 
         # sort the args into positional and optional.
@@ -147,7 +153,7 @@ class Command():
 # }
         # build the docstring.
         docstring = f'{self.name}('
-        posnames = [a[0] for a in posargs]
+        posnames = [a[0] for a in posargs if a is not None]
         docstring += ", ".join(posnames)
         optnames = [f'{a[0]}={str(a[1].get("default_val", None))}' for a in optargs]
         docstring += ','.join(optnames)
@@ -157,12 +163,13 @@ class Command():
         docstring += '\n'
         docstring += 'Parameters:\n'
         for a in posargs:
-            docstring += f'{a[0]}: {a[1].get("type", "Unknown type")}\n'
-            docstring += f'\t{a[1].get("desc","No description.")}\n'
+            if a is not None:
+                docstring += f'{a[0]}: {a[1].get("type", "Unknown type")}\n'
+                docstring += f'\t{a[1].get("desc", "No description.")}\n'
 
         for a in optargs:
             docstring += f'{a[0]}: {a[1].get("type", "Unknown type")}, default={str(a[1].get("default_val", None))}\n'
-            docstring += f'\t{a[1].get("desc","No description.")}\n'
+            docstring += f'\t{a[1].get("desc", "No description.")}\n'
         docstring += '\n'
         retname = self.returns.get('name', '')
         if retname:
@@ -173,36 +180,37 @@ class Command():
         return docstring
 
     @property
-    def method_name(self):
+    def method_name(self) -> str:
         return self.jsondict.get('method_name', self.name)
 
     @property
-    def exe_name(self):
+    def exe_name(self) -> str:
         return self.jsondict.get('exe_name', self.name)
 
     @property
-    def desc(self):
+    def desc(self) -> str:
         return self.jsondict.get('desc', 'No description')
 
     @property
-    def returns(self):
+    def returns(self) -> AnyDict:
         return self.jsondict.get('returns', {})
 
 
 class Clippy:
-    def __init__(self, clippy_cfg=None, cmd_prefix='', loglevel=0):
+    def __init__(self, clippy_cfg: Optional[AnyDict] = None, cmd_prefix: str = '', loglevel: int = 0):
         self.clippy_cfg = clippy_cfg
         self.cmd_prefix = cmd_prefix.split()
-        self.namespaces = []
+        self.namespaces: List[str] = []
         self.uuid = uuid.uuid4()
         self.logger = logging.getLogger(self.uuid.hex)
         handler = logging.StreamHandler(sys.stderr)
         self.logger.addHandler(handler)
         self.logger.setLevel(config.loglevel)
         self.logger.info(f'Logger set to {self.logger.getEffectiveLevel()}')
-        self.add_namespaces(clippy_cfg)
+        if clippy_cfg is not None:
+            self.add_namespaces(clippy_cfg)
 
-    def add_namespaces(self, cmd_dict):
+    def add_namespaces(self, cmd_dict: AnyDict):
         '''
         Adds namespaces to / replaces namespaces in a current
         Clippy object. Namespaces should be a dictionary
@@ -230,18 +238,17 @@ class Clippy:
                     self.logger.debug(f'Adding registered command: {name}')
                     cmd = Command(namespace, name, self, jsondict)
                     setattr(inner, name, types.MethodType(cmd.genfn(cmd.docstring), self))
-                    inner.methods.append(name)
+                    inner.methods.append(name)  # type: ignore
                 else:
-                    print(f'{name} is a class');
+                    print(f'{name} is a class')  # TODO: is this a debug statement?
                     setattr(inner, name, jsondict)
-                    inner.classes.append(name)
-
+                    inner.classes.append(name)  # type: ignore
             setattr(self, namespace, inner)
 
     def logo(self):
         logo()
 
-    def _validate(self, cmd, submission_dict):
+    def _validate(self, cmd: str, submission_dict: AnyDict) -> Tuple[bool, str]:
         '''
         Internal command.
 
@@ -265,7 +272,7 @@ class Clippy:
         self.logger.debug(f'Validation returning {ret}')
         return (ret, warn)
 
-    def _run(self, cmd, submission_dict):
+    def _run(self, cmd: str, submission_dict: AnyDict) -> AnyDict:
         '''
         Processes a submission locally (no remote server).
         Returns a Python dictionary of results, or throws

--- a/clippy/config.py
+++ b/clippy/config.py
@@ -3,14 +3,16 @@
 #
 # SPDX-License-Identifier: MIT
 
+from clippy import AnyDict
+
 # command prefix used to specify clippy task management with the HPC cluster
 # for instance, if using slurm this could be set to 'srun -n1 -ppdebug'
-cmd_prefix = ''
+cmd_prefix: str = ''
 
 # contol the log level of clippy
-loglevel = 0
+loglevel: int = 0
 
 # PRIVATE: this dict contains the class types that clippy has constructed.
 #          once constructed clippy will get the definition from this dict
 #          to create new instances.
-_dynamic_types = {}
+_dynamic_types: AnyDict = {}

--- a/clippy/error.py
+++ b/clippy/error.py
@@ -32,11 +32,13 @@ class ClippyValidationError(ClippyError):
     '''
     pass
 
+
 class ClippySerializationError(ClippyError):
     '''
     This error should be thrown when clippy object serialization fails
     '''
     pass
+
 
 class ClippyClassInconsistencyError(ClippyError):
     '''

--- a/clippy/expression.py
+++ b/clippy/expression.py
@@ -1,5 +1,5 @@
-import json
 from clippy.serialization import ClippySerializable
+
 
 class Expression(ClippySerializable):
     def __init__(self, op, o1, o2):
@@ -13,44 +13,64 @@ class Expression(ClippySerializable):
 
     def __lt__(self, o):
         return self._express("<", o)
+
     def __le__(self, o):
         return self._express("<=", o)
+
     def __eq__(self, o):
-        return self._express("==",o)
+        return self._express("==", o)
+
     def __ne__(self, o):
-        return self._express("!=",o)
+        return self._express("!=", o)
+
     def __gt__(self, o):
-        return self._express(">",o)
+        return self._express(">", o)
+
     def __ge__(self, o):
-        return self._express(">=",o)
+        return self._express(">=", o)
+
     def __add__(self, o):
-        return self._express("+",o)
+        return self._express("+", o)
+
     def __sub__(self, o):
-        return self._express("-",o)
+        return self._express("-", o)
+
     def __mul__(self, o):
-        return self._express("*",o)
+        return self._express("*", o)
+
     def __matmul__(self, o):
-        return self._express("@",o)
+        return self._express("@", o)
+
     def __truediv__(self, o):
-        return self._express("/",o)
+        return self._express("/", o)
+
     def __floordiv__(self, o):
-        return self._express("//",o)
+        return self._express("//", o)
+
     def __mod__(self, o):
-        return self._express("%",o)
+        return self._express("%", o)
+
     def __divmod__(self, o):
-        return self._express("divmod",o)
+        return self._express("divmod", o)
+
     def __pow__(self, o, modulo=None):
-        return self._express("**",o, module=module)
+        return self._express("**", o, modulo=modulo)
+
     def __lshift__(self, o):
-        return self._express("<<",o)
+        return self._express("<<", o)
+
     def __rshift__(self, o):
-        return self._express(">>",o)
+        return self._express(">>", o)
+
     def __and__(self, o):
-        return self._express("and",o)
+        return self._express("and", o)
+
     def __xor__(self, o):
-        return self._express("^",o)
+        return self._express("^", o)
+
     def __or__(self, o):
-        return self._express("or",o)
+        return self._express("or", o)
+
     def __contains__(self, o):
         raise NotImplementedError("syntax a in b is not supported. Use b.contains(a) instead.")
         # will not work when written as "x in set",
@@ -63,11 +83,11 @@ class Expression(ClippySerializable):
     def contains(self, o, regex=False):
         oper = "in" if not regex else "regex"
         return Expression(oper, o, self)
-#        return self._express(oper,o)
+#        return self._express(oper, o)
 
     # string and array concatenation
     def cat(self, o):
-        return self._express("cat",o)
+        return self._express("cat", o)
 
     def __str__(self):
         return self.to_json()
@@ -87,6 +107,7 @@ class Expression(ClippySerializable):
 
         return {self.op: [o1, o2]}
 
+
 class Field(Expression):
     def __init__(self, name):
         self.name = name
@@ -95,10 +116,11 @@ class Field(Expression):
         # ~ return f"{{\"var\": [\"{self.name}\"]}}"
 
     def to_serial(self):
-      return {"var": self.name}
+        return {"var": self.name}
 
     def _express(self, op, o, **kwargs):
         return Expression(op, self, o)
+
 
 class Selector:
     def __init__(self, parent, name):


### PR DESCRIPTION
Needs review by @ppete and @rogerpearce 
This passes mypy checks but we really need to tighten up some of the datatype specifications here. I've created an `AnyDict` type alias (easy to search for) that represents `Dict[str, Any]` - we should make an effort to remove these (and any other use of `Any`) for proper typing.

I didn't touch `expressions.py`, and `serialization.py` is still problematic.

Next up is integrating mypy checks into CI.