### PR TITLE
fs backend: executables are now validated using threads

### DIFF
--- a/py/src/clippy/backends/fs/__init__.py
+++ b/py/src/clippy/backends/fs/__init__.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import stat
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from subprocess import CalledProcessError
 from typing import Any
 
@@ -115,13 +116,29 @@ def _create_class(name: str, path: str, topcfg: CLIPPY_CONFIG):
 
     cls = type(name, (ClippySerializable,), meta)
     classpath = pathlib.Path(path, name)
+    executables = []
     for file in os.scandir(classpath):
         fullpath = pathlib.Path(classpath, file)
         if _is_user_executable(fullpath):
+            executables.append(fullpath)
+
+    # Query executable metadata concurrently, then install methods in scan order.
+    # Installing sequentially preserves deterministic behavior when multiple
+    # executables expose the same method name.
+    with ThreadPoolExecutor() as executor:
+        definitions = [
+            (executable, executor.submit(_get_method_definition, str(executable), class_logger))
+            for executable in executables
+        ]
+
+        for executable, definition in definitions:
             try:
-                _process_executable(str(fullpath), cls)
+                method, docstring, args = definition.result()
             except ClippyConfigurationError as e:
-                class_logger.warning("error processing %s: %s; ignoring", fullpath, e)
+                class_logger.warning("error processing %s: %s; ignoring", executable, e)
+                continue
+
+            _install_method(str(executable), cls, method, docstring, args)
 
     # add the selectors
     # this should be in the meta.json file.
@@ -140,10 +157,16 @@ def _process_executable(executable: str, cls):
              symtable (by default globals()).
     """
 
-    # grab the help string, which gives us the docstring and  all arguments.
-    cls.logger.debug("processing executable %s", executable)
+    method, docstring, args = _get_method_definition(executable, cls.logger)
+    _install_method(executable, cls, method, docstring, args)
+    return cls
+
+
+def _get_method_definition(executable: str, logger):
+    """Query an executable and return the information needed to define its method."""
+    logger.debug("processing executable %s", executable)
     try:
-        j = _help(executable, {}, cls.logger)
+        j = _help(executable, {}, logger)
 
     except CalledProcessError as e:
         raise ClippyConfigurationError("Execution error " + e.stderr) from e
@@ -182,10 +205,14 @@ def _process_executable(executable: str, cls):
 
     # if we don't explicitly pass the method name, use the name of the exe.
     method = j.get(clippy_constants.METHODNAME_KEY, os.path.basename(executable))
+    return method, docstring, args
+
+
+def _install_method(executable: str, cls, method: str, docstring: str, args: dict[str, dict]) -> None:
+    """Install a previously discovered executable method on a generated class."""
     if hasattr(cls, method) and not method.startswith("__"):
         cls.logger.warning(f"Overwriting existing method {method} for class {cls} with executable {executable}")
     _define_method(cls, method, executable, docstring, args)
-    return cls
 
 
 def _define_method(cls, name: str, executable: str, docstr: str, arguments: dict[str, dict] | None):  # pylint: disable=too-complex

--- a/py/src/clippy/backends/fs/execution.py
+++ b/py/src/clippy/backends/fs/execution.py
@@ -61,9 +61,20 @@ def _stream_exec(
         assert proc.stdout is not None
         assert proc.stderr is not None
 
-        proc.stdin.write(cmd_stdin + "\n")
-        proc.stdin.flush()
-        proc.stdin.close()
+        # A command such as --clippy-help may exit without reading stdin. This
+        # is more likely to happen when several commands start concurrently,
+        # so tolerate the same early pipe closure as subprocess.communicate().
+        stdin = proc.stdin
+        try:
+            stdin.write(cmd_stdin + "\n")
+            stdin.flush()
+        except BrokenPipeError:
+            pass
+        finally:
+            with contextlib.suppress(BrokenPipeError):
+                stdin.close()
+            # Prevent Popen.__exit__ from trying to flush a broken pipe again.
+            proc.stdin = None
 
         progress = None
         # Use select with file descriptors and non-blocking reads


### PR DESCRIPTION
This results in ~7.25x performance speedup on development machines:

| Metric | Unthreaded | Threaded | Improvement |
|---|---:|---:|---:|
| Samples | 10 | 30 | — |
| Mean | 1,815.5 ms | 250.6 ms | **7.25× faster** |
| Median | 1,811.5 ms | 249.1 ms | **7.27× faster** |
| Minimum | 1,754.5 ms | 241.9 ms | — |
| Maximum | 1,879.3 ms | 274.2 ms | — |
| Standard deviation | 33.2 ms | 7.1 ms | — |
| Mean time reduction | — | — | **86.2%** |